### PR TITLE
feat(erd): interactive ERD with React Flow

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,10 +8,12 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@dagrejs/dagre": "^3.0.0",
         "@monaco-editor/react": "^4.7.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
+        "@xyflow/react": "^12.10.2",
         "lucide-react": "^1.7.0",
         "mermaid": "^11.14.0",
         "react": "^19.2.4",
@@ -329,6 +331,19 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
       "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA=="
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
@@ -1531,7 +1546,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1900,6 +1915,36 @@
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
       "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2103,6 +2148,11 @@
         "chevrotain": "^12.0.0"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2180,7 +2230,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cytoscape": {
@@ -4420,6 +4470,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
@@ -4627,6 +4685,33 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,10 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@monaco-editor/react": "^4.7.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "@xyflow/react": "^12.10.2",
     "lucide-react": "^1.7.0",
     "mermaid": "^11.14.0",
     "react": "^19.2.4",

--- a/frontend/src/components/RDSERDView.tsx
+++ b/frontend/src/components/RDSERDView.tsx
@@ -1,112 +1,181 @@
-import { useEffect, useRef, useState } from "react";
-import { AlertCircle, Copy, Loader2 } from "lucide-react";
-import type { RDSERDResponse } from "../types";
+import { useCallback, useMemo } from "react";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  type Node,
+  type Edge,
+  type NodeTypes,
+  type NodeProps,
+  Handle,
+  Position,
+  useNodesState,
+  useEdgesState,
+  MarkerType,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
+import dagre from "@dagrejs/dagre";
+import { Copy, KeyRound, Link } from "lucide-react";
+import type { RDSERDResponse, RDSERDTable, RDSERDEdge } from "../types";
 
-/** Mermaid identifier rule: alphanumeric + underscore. Otherwise wrap in quotes. */
-function safeIdent(s: string): string {
-  if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(s)) return s;
-  return `"${s.replace(/"/g, '\\"')}"`;
+const NODE_WIDTH = 260;
+const COLUMN_ROW_HEIGHT = 24;
+const HEADER_HEIGHT = 36;
+const PADDING_BOTTOM = 8;
+
+function nodeHeight(table: RDSERDTable): number {
+  return HEADER_HEIGHT + table.columns.length * COLUMN_ROW_HEIGHT + PADDING_BOTTOM;
 }
 
-/** Mermaid type token must match [a-zA-Z_][a-zA-Z0-9_]*. */
-function safeType(s: string): string {
-  return s.replace(/[^a-zA-Z0-9_]/g, "_") || "unknown";
-}
+/** Dagre auto-layout: compute x/y for each node. */
+function layoutNodes(
+  tables: RDSERDTable[],
+  edges: RDSERDEdge[],
+): { nodes: Node[]; edges: Edge[] } {
+  const g = new dagre.graphlib.Graph();
+  g.setDefaultEdgeLabel(() => ({}));
+  g.setGraph({ rankdir: "TB", nodesep: 60, ranksep: 80, marginx: 40, marginy: 40 });
 
-/** Build mermaid erDiagram source from the API response. */
-function buildERDSource(data: RDSERDResponse): string {
-  const lines: string[] = ["erDiagram"];
-
-  for (const t of data.tables) {
-    lines.push(`  ${safeIdent(t.name)} {`);
-    for (const c of t.columns) {
-      const marks = [
-        c.is_primary_key ? "PK" : null,
-        c.is_foreign_key ? "FK" : null,
-      ]
-        .filter(Boolean)
-        .join(",");
-      const tail = marks ? ` ${marks}` : "";
-      lines.push(`    ${safeType(c.data_type)} ${safeIdent(c.name)}${tail}`);
-    }
-    lines.push(`  }`);
+  for (const t of tables) {
+    const h = nodeHeight(t);
+    g.setNode(t.name, { width: NODE_WIDTH, height: h });
   }
 
-  for (const e of data.edges) {
-    // Child rows reference one parent row → child }o--|| parent.
-    // Mermaid `: "label"` shows on the edge.
-    lines.push(
-      `  ${safeIdent(e.from_table)} }o--|| ${safeIdent(e.to_table)} : "${e.from_column}"`,
-    );
+  for (const e of edges) {
+    g.setEdge(e.from_table, e.to_table);
   }
 
-  return lines.join("\n");
-}
+  dagre.layout(g);
 
-export function RDSERDView({ data }: { data: RDSERDResponse }) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [svg, setSvg] = useState<string | null>(null);
-  const [renderError, setRenderError] = useState<string | null>(null);
-  const [rendering, setRendering] = useState(true);
-  const source = buildERDSource(data);
-
-  useEffect(() => {
-    let cancelled = false;
-    setRendering(true);
-    setRenderError(null);
-    setSvg(null);
-
-    // Lazy import to keep mermaid out of the initial bundle.
-    import("mermaid")
-      .then(async ({ default: mermaid }) => {
-        mermaid.initialize({
-          startOnLoad: false,
-          theme: "dark",
-          themeVariables: {
-            background: "#0f172a",
-            primaryColor: "#1e293b",
-            primaryTextColor: "#e2e8f0",
-            primaryBorderColor: "#334155",
-            lineColor: "#64748b",
-            secondaryColor: "#0f172a",
-            tertiaryColor: "#1e293b",
-          },
-          er: {
-            layoutDirection: "TB",
-            entityPadding: 12,
-            useMaxWidth: true,
-          },
-          securityLevel: "strict",
-        });
-        // Use a unique id per render to avoid mermaid's internal cache collisions.
-        const id = `erd-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
-        try {
-          const { svg } = await mermaid.render(id, source);
-          if (!cancelled) {
-            setSvg(svg);
-            setRendering(false);
-          }
-        } catch (e) {
-          if (!cancelled) {
-            setRenderError(e instanceof Error ? e.message : String(e));
-            setRendering(false);
-          }
-        }
-      })
-      .catch((e) => {
-        if (!cancelled) {
-          setRenderError(`failed to load mermaid: ${e instanceof Error ? e.message : String(e)}`);
-          setRendering(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
+  const flowNodes: Node[] = tables.map((t) => {
+    const pos = g.node(t.name);
+    const h = nodeHeight(t);
+    return {
+      id: t.name,
+      type: "tableNode",
+      position: { x: pos.x - NODE_WIDTH / 2, y: pos.y - h / 2 },
+      data: { table: t },
     };
-  }, [source]);
+  });
+
+  const flowEdges: Edge[] = edges.map((e, i) => ({
+    id: `edge-${i}`,
+    source: e.from_table,
+    target: e.to_table,
+    sourceHandle: `${e.from_table}-${e.from_column}-source`,
+    targetHandle: `${e.to_table}-${e.to_column}-target`,
+    label: `${e.from_column} → ${e.to_column}`,
+    type: "smoothstep",
+    animated: true,
+    markerEnd: { type: MarkerType.ArrowClosed, color: "#06b6d4" },
+    style: { stroke: "#334155", strokeWidth: 1.5 },
+    labelStyle: { fill: "#94a3b8", fontSize: 10, fontWeight: 500 },
+    labelBgStyle: { fill: "#0f172a", fillOpacity: 0.9 },
+    labelBgPadding: [6, 3] as [number, number],
+    labelBgBorderRadius: 4,
+  }));
+
+  return { nodes: flowNodes, edges: flowEdges };
+}
+
+/** Custom node: renders a table card with columns. */
+function TableNode({ data, selected }: NodeProps) {
+  const table = (data as { table: RDSERDTable }).table;
+
+  return (
+    <div
+      className={`rounded-lg border overflow-hidden shadow-lg transition-colors ${
+        selected
+          ? "border-cyan-400 shadow-cyan-500/20"
+          : "border-slate-600 hover:border-slate-500"
+      }`}
+      style={{ width: NODE_WIDTH, background: "#1e293b" }}
+    >
+      {/* Header */}
+      <div
+        className="px-3 py-2 text-sm font-semibold text-slate-100 border-b border-slate-600 flex items-center gap-2"
+        style={{ height: HEADER_HEIGHT, background: "#0f172a" }}
+      >
+        <span className="truncate">{table.name}</span>
+        <span className="ml-auto text-xs text-slate-500">{table.columns.length} cols</span>
+      </div>
+
+      {/* Columns */}
+      <div>
+        {table.columns.map((col) => (
+          <div
+            key={col.name}
+            className="relative flex items-center px-3 text-xs border-b border-slate-700/50 last:border-b-0 hover:bg-slate-700/30"
+            style={{ height: COLUMN_ROW_HEIGHT }}
+          >
+            <Handle
+              type="target"
+              position={Position.Left}
+              id={`${table.name}-${col.name}-target`}
+              className="!w-2 !h-2 !bg-cyan-500 !border-slate-800"
+              style={{ left: -4 }}
+            />
+            <div className="flex items-center gap-1.5 min-w-0 flex-1">
+              {col.is_primary_key && <KeyRound size={10} className="text-amber-400 shrink-0" />}
+              {col.is_foreign_key && <Link size={10} className="text-cyan-400 shrink-0" />}
+              <span className="text-slate-200 truncate">{col.name}</span>
+            </div>
+            <span className="text-slate-500 font-mono ml-2 shrink-0">{col.data_type}</span>
+            <Handle
+              type="source"
+              position={Position.Right}
+              id={`${table.name}-${col.name}-source`}
+              className="!w-2 !h-2 !bg-cyan-500 !border-slate-800"
+              style={{ right: -4 }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const nodeTypes: NodeTypes = { tableNode: TableNode };
+
+export function RDSERDView({
+  data,
+  onTableClick,
+}: {
+  data: RDSERDResponse;
+  onTableClick?: (tableName: string) => void;
+}) {
+  const { nodes: initialNodes, edges: initialEdges } = useMemo(
+    () => layoutNodes(data.tables, data.edges),
+    [data],
+  );
+
+  const [nodes, , onNodesChange] = useNodesState(initialNodes);
+  const [edges, , onEdgesChange] = useEdgesState(initialEdges);
+
+  const handleNodeClick = useCallback(
+    (_: React.MouseEvent, node: Node) => {
+      onTableClick?.(node.id);
+    },
+    [onTableClick],
+  );
 
   const copySource = () => {
-    navigator.clipboard?.writeText(source).catch(() => {});
+    const lines = ["erDiagram"];
+    for (const t of data.tables) {
+      lines.push(`  ${t.name} {`);
+      for (const c of t.columns) {
+        const marks = [c.is_primary_key ? "PK" : null, c.is_foreign_key ? "FK" : null]
+          .filter(Boolean)
+          .join(",");
+        lines.push(`    ${c.data_type} ${c.name}${marks ? ` ${marks}` : ""}`);
+      }
+      lines.push("  }");
+    }
+    for (const e of data.edges) {
+      lines.push(`  ${e.from_table} }o--|| ${e.to_table} : "${e.from_column}"`);
+    }
+    navigator.clipboard?.writeText(lines.join("\n")).catch(() => {});
   };
 
   return (
@@ -120,6 +189,9 @@ export function RDSERDView({ data }: { data: RDSERDResponse }) {
             </span>
           )}
         </span>
+        {onTableClick && (
+          <span className="text-slate-500">click a table to view details</span>
+        )}
         <button
           onClick={copySource}
           className="ml-auto flex items-center gap-1 text-slate-400 hover:text-white px-2 py-1 rounded hover:bg-slate-800/60"
@@ -130,36 +202,36 @@ export function RDSERDView({ data }: { data: RDSERDResponse }) {
         </button>
       </div>
 
-      <div className="rounded border border-slate-700 bg-slate-950/60 overflow-auto p-4">
-        {rendering && (
-          <div className="flex items-center justify-center h-64 text-slate-400">
-            <Loader2 size={24} className="animate-spin" />
-          </div>
-        )}
-
-        {!rendering && renderError && (
-          <div className="space-y-2">
-            <div className="flex items-start gap-2 rounded border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-300">
-              <AlertCircle size={16} className="mt-0.5 shrink-0" />
-              <span>Failed to render ERD: {renderError}</span>
-            </div>
-            <details className="text-xs text-slate-500">
-              <summary className="cursor-pointer hover:text-slate-400">Show mermaid source</summary>
-              <pre className="mt-2 p-2 bg-slate-900 rounded overflow-x-auto text-slate-400">
-                {source}
-              </pre>
-            </details>
-          </div>
-        )}
-
-        {!rendering && !renderError && svg && (
-          <div
-            ref={containerRef}
-            className="erd-svg-host"
-            // mermaid produces inline SVG that we trust (we built the source ourselves).
-            dangerouslySetInnerHTML={{ __html: svg }}
+      <div
+        className="rounded border border-slate-700 bg-slate-950/60 overflow-hidden"
+        style={{ height: "70vh", minHeight: 400 }}
+      >
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onNodeClick={handleNodeClick}
+          nodeTypes={nodeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.2 }}
+          minZoom={0.1}
+          maxZoom={2}
+          proOptions={{ hideAttribution: true }}
+          defaultEdgeOptions={{ type: "smoothstep" }}
+        >
+          <Background color="#1e293b" gap={20} size={1} />
+          <Controls
+            showInteractive={false}
+            className="!bg-slate-800 !border-slate-700 !shadow-lg [&>button]:!bg-slate-800 [&>button]:!border-slate-600 [&>button]:!text-slate-300 [&>button:hover]:!bg-slate-700"
           />
-        )}
+          <MiniMap
+            nodeColor="#1e293b"
+            nodeStrokeColor="#334155"
+            maskColor="rgba(15, 23, 42, 0.7)"
+            className="!bg-slate-900 !border-slate-700"
+          />
+        </ReactFlow>
       </div>
     </div>
   );

--- a/frontend/src/components/RDSOverviewPanel.tsx
+++ b/frontend/src/components/RDSOverviewPanel.tsx
@@ -159,6 +159,11 @@ export function RDSOverviewPanel() {
             error={erdError}
             data={erdData}
             onBack={() => setErdSchema(null)}
+            onTableClick={(tableName) => {
+              setErdSchema(null);
+              setSelectedSchema(erdSchema);
+              setSelectedTable(tableName);
+            }}
           />
         ) : selectedSchema && selectedTable ? (
           <TableDetailDrilldown
@@ -593,6 +598,7 @@ function ERDDrilldown({
   error,
   data,
   onBack,
+  onTableClick,
 }: {
   schema: string;
   db: string;
@@ -600,6 +606,7 @@ function ERDDrilldown({
   error: string | null;
   data: RDSERDResponse | null;
   onBack: () => void;
+  onTableClick: (tableName: string) => void;
 }) {
   return (
     <>
@@ -636,7 +643,9 @@ function ERDDrilldown({
         </div>
       )}
 
-      {!loading && !error && data && <RDSERDView data={data} />}
+      {!loading && !error && data && (
+        <RDSERDView data={data} onTableClick={onTableClick} />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Mermaid.js 기반 정적 SVG ERD를 `@xyflow/react` (React Flow) 기반 인터랙티브 ERD로 교체
- `@dagrejs/dagre`로 자동 레이아웃 (top-to-bottom)
- 커스텀 테이블 노드: 테이블명 + 컬럼 목록 + PK/FK 아이콘
- FK 관계를 animated smoothstep 엣지로 시각화
- **노드 클릭 시 해당 테이블의 detail view로 점프**
- 드래그, 줌, 팬, MiniMap, Controls 지원
- 다크 테마 일관성 유지

Closes #17

## Test plan
- [ ] RDS 스키마에서 "View ERD" 클릭 → React Flow 기반 인터랙티브 다이어그램 렌더링 확인
- [ ] 테이블 노드 드래그/줌/팬 동작 확인
- [ ] 테이블 노드 클릭 → 해당 테이블 detail view 전환 확인
- [ ] FK 엣지 라벨 (from_column → to_column) 표시 확인
- [ ] MiniMap, Controls 정상 동작 확인
- [ ] "Copy mermaid" 버튼 기존 기능 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)