### PR TITLE
feat(terminal): web terminal — SSH shell in browser

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-web-links": "^0.12.0",
+        "@xterm/xterm": "^6.0.0",
         "lucide-react": "^1.7.0",
         "mermaid": "^11.14.0",
         "react": "^19.2.4",
@@ -1881,6 +1884,21 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+      "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw=="
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="
     },
     "node_modules/acorn": {
       "version": "8.16.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,9 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-web-links": "^0.12.0",
+    "@xterm/xterm": "^6.0.0",
     "lucide-react": "^1.7.0",
     "mermaid": "^11.14.0",
     "react": "^19.2.4",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,10 +4,11 @@ import { Dashboard } from "./components/Dashboard";
 import { FileExplorer } from "./components/FileExplorer";
 import { S3Browser } from "./components/S3Browser";
 import { RDSOverviewPanel } from "./components/RDSOverviewPanel";
+import { Terminal } from "./components/Terminal";
 import { ConnectionModal } from "./components/ConnectionModal";
 
 function App() {
-  const [activeView, setActiveView] = useState<"dashboard" | "ec2" | "s3" | "rds">("dashboard");
+  const [activeView, setActiveView] = useState<"dashboard" | "ec2" | "s3" | "rds" | "terminal">("dashboard");
   const [showConnections, setShowConnections] = useState(false);
 
   return (
@@ -22,6 +23,7 @@ function App() {
         {activeView === "ec2" && <FileExplorer />}
         {activeView === "s3" && <S3Browser />}
         {activeView === "rds" && <RDSOverviewPanel />}
+        {activeView === "terminal" && <Terminal />}
       </main>
 
       {showConnections && <ConnectionModal onClose={() => setShowConnections(false)} />}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
-import { Monitor, HardDrive, Plus, Settings, LayoutDashboard, Database } from "lucide-react";
+import { Monitor, HardDrive, Plus, Settings, LayoutDashboard, Database, TerminalSquare } from "lucide-react";
 
-type View = "dashboard" | "ec2" | "s3" | "rds";
+type View = "dashboard" | "ec2" | "s3" | "rds" | "terminal";
 
 interface Props {
   activeView: View;
@@ -44,6 +44,7 @@ export function Sidebar({ activeView, onViewChange, onOpenConnections }: Props) 
         <NavButton active={activeView === "ec2"} icon={Monitor} label="File Explorer" onClick={() => onViewChange("ec2")} />
         <NavButton active={activeView === "s3"} icon={HardDrive} label="S3 Browser" onClick={() => onViewChange("s3")} />
         <NavButton active={activeView === "rds"} icon={Database} label="RDS PostgreSQL" onClick={() => onViewChange("rds")} />
+        <NavButton active={activeView === "terminal"} icon={TerminalSquare} label="Terminal" onClick={() => onViewChange("terminal")} />
       </div>
 
       <div className="p-3 border-t border-slate-700">

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -12,73 +12,108 @@ interface TermSession {
   label: string;
   term: XTerm;
   fitAddon: FitAddon;
-  ws: WebSocket | null;
+  ws: WebSocket;
   status: "connecting" | "connected" | "disconnected";
 }
 
 let nextId = 1;
 
-function createSession(connId?: string): TermSession {
-  const id = nextId++;
-  const term = new XTerm({
-    cursorBlink: true,
-    fontSize: 13,
-    fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace",
-    theme: {
-      background: "#0f172a",
-      foreground: "#e2e8f0",
-      cursor: "#22d3ee",
-      selectionBackground: "#334155",
-      black: "#0f172a",
-      red: "#f87171",
-      green: "#4ade80",
-      yellow: "#facc15",
-      blue: "#60a5fa",
-      magenta: "#c084fc",
-      cyan: "#22d3ee",
-      white: "#e2e8f0",
-      brightBlack: "#475569",
-      brightRed: "#fca5a5",
-      brightGreen: "#86efac",
-      brightYellow: "#fde68a",
-      brightBlue: "#93c5fd",
-      brightMagenta: "#d8b4fe",
-      brightCyan: "#67e8f9",
-      brightWhite: "#f8fafc",
-    },
-    scrollback: 5000,
-    allowProposedApi: true,
-  });
-
-  const fitAddon = new FitAddon();
-  term.loadAddon(fitAddon);
-  term.loadAddon(new WebLinksAddon());
-
-  const params = connId ? `?conn=${encodeURIComponent(connId)}` : "";
-  const ws = new WebSocket(`${WS_BASE}${params}`);
-  ws.binaryType = "arraybuffer";
-
-  return {
-    id,
-    label: `Terminal ${id}`,
-    term,
-    fitAddon,
-    ws,
-    status: "connecting",
-  };
-}
-
 export function Terminal() {
   const [sessions, setSessions] = useState<TermSession[]>([]);
   const [activeId, setActiveId] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const wiredIds = useRef<Set<number>>(new Set());
   const activeSession = sessions.find((s) => s.id === activeId) ?? null;
 
-  const addSession = useCallback(() => {
-    const session = createSession();
+  const addSession = useCallback((connId?: string) => {
+    const id = nextId++;
+
+    const term = new XTerm({
+      cursorBlink: true,
+      fontSize: 13,
+      fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace",
+      theme: {
+        background: "#0f172a",
+        foreground: "#e2e8f0",
+        cursor: "#22d3ee",
+        selectionBackground: "#334155",
+        black: "#0f172a",
+        red: "#f87171",
+        green: "#4ade80",
+        yellow: "#facc15",
+        blue: "#60a5fa",
+        magenta: "#c084fc",
+        cyan: "#22d3ee",
+        white: "#e2e8f0",
+        brightBlack: "#475569",
+        brightRed: "#fca5a5",
+        brightGreen: "#86efac",
+        brightYellow: "#fde68a",
+        brightBlue: "#93c5fd",
+        brightMagenta: "#d8b4fe",
+        brightCyan: "#67e8f9",
+        brightWhite: "#f8fafc",
+      },
+      scrollback: 5000,
+      allowProposedApi: true,
+    });
+
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.loadAddon(new WebLinksAddon());
+
+    const params = connId ? `?conn=${encodeURIComponent(connId)}` : "";
+    const ws = new WebSocket(`${WS_BASE}${params}`);
+    ws.binaryType = "arraybuffer";
+
+    // Wire WebSocket events immediately (before adding to state)
+    ws.onopen = () => {
+      setSessions((prev) =>
+        prev.map((s) => (s.id === id ? { ...s, status: "connected" as const } : s)),
+      );
+      const msg = JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows });
+      ws.send(msg);
+    };
+
+    ws.onmessage = (ev) => {
+      if (ev.data instanceof ArrayBuffer) {
+        term.write(new Uint8Array(ev.data));
+      } else {
+        term.write(ev.data as string);
+      }
+    };
+
+    ws.onclose = () => {
+      setSessions((prev) =>
+        prev.map((s) => (s.id === id ? { ...s, status: "disconnected" as const } : s)),
+      );
+      term.write("\r\n\x1b[90m--- session ended ---\x1b[0m\r\n");
+    };
+
+    ws.onerror = () => {
+      setSessions((prev) =>
+        prev.map((s) => (s.id === id ? { ...s, status: "disconnected" as const } : s)),
+      );
+    };
+
+    // Terminal input → WebSocket (binary)
+    const encoder = new TextEncoder();
+    term.onData((data) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(encoder.encode(data));
+      }
+    });
+
+    const session: TermSession = {
+      id,
+      label: `Terminal ${id}`,
+      term,
+      fitAddon,
+      ws,
+      status: "connecting",
+    };
+
     setSessions((prev) => [...prev, session]);
-    setActiveId(session.id);
+    setActiveId(id);
   }, []);
 
   const removeSession = useCallback(
@@ -86,9 +121,8 @@ export function Terminal() {
       setSessions((prev) => {
         const session = prev.find((s) => s.id === id);
         if (session) {
-          session.ws?.close();
+          session.ws.close();
           session.term.dispose();
-          wiredIds.current.delete(id);
         }
         const next = prev.filter((s) => s.id !== id);
         if (activeId === id) {
@@ -102,9 +136,7 @@ export function Terminal() {
 
   // Auto-create first session on mount
   useEffect(() => {
-    if (sessions.length === 0) {
-      addSession();
-    }
+    addSession();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Attach active terminal to DOM
@@ -112,69 +144,13 @@ export function Terminal() {
     const el = containerRef.current;
     if (!el || !activeSession) return;
 
-    // Clear container and attach
     el.innerHTML = "";
     activeSession.term.open(el);
 
-    // Fit after a frame so the container dimensions are settled
     requestAnimationFrame(() => {
       activeSession.fitAddon.fit();
     });
   }, [activeSession]);
-
-  // Wire up WebSocket ↔ xterm for each session
-  useEffect(() => {
-    for (const session of sessions) {
-      const { ws, term } = session;
-      if (!ws || ws.readyState > WebSocket.OPEN) continue;
-
-      // Skip if already wired
-      if (wiredIds.current.has(session.id)) continue;
-      wiredIds.current.add(session.id);
-
-      ws.onopen = () => {
-        setSessions((prev) =>
-          prev.map((s) => (s.id === session.id ? { ...s, status: "connected" as const } : s)),
-        );
-        // Send initial size
-        const msg = JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows });
-        ws.send(msg);
-      };
-
-      ws.onmessage = (ev) => {
-        if (ev.data instanceof ArrayBuffer) {
-          term.write(new Uint8Array(ev.data));
-        } else {
-          term.write(ev.data);
-        }
-      };
-
-      ws.onclose = () => {
-        setSessions((prev) =>
-          prev.map((s) =>
-            s.id === session.id ? { ...s, status: "disconnected" as const } : s,
-          ),
-        );
-        term.write("\r\n\x1b[90m--- session ended ---\x1b[0m\r\n");
-      };
-
-      ws.onerror = () => {
-        setSessions((prev) =>
-          prev.map((s) =>
-            s.id === session.id ? { ...s, status: "disconnected" as const } : s,
-          ),
-        );
-      };
-
-      // Terminal input → WebSocket (binary)
-      term.onData((data) => {
-        if (ws.readyState === WebSocket.OPEN) {
-          const encoder = new TextEncoder();
-          ws.send(encoder.encode(data));
-        }
-      });
-    }
-  }, [sessions]);
 
   // Resize observer
   useEffect(() => {
@@ -182,7 +158,7 @@ export function Terminal() {
 
     const observer = new ResizeObserver(() => {
       activeSession.fitAddon.fit();
-      if (activeSession.ws?.readyState === WebSocket.OPEN) {
+      if (activeSession.ws.readyState === WebSocket.OPEN) {
         const msg = JSON.stringify({
           type: "resize",
           cols: activeSession.term.cols,
@@ -234,7 +210,7 @@ export function Terminal() {
           ))}
         </div>
         <button
-          onClick={addSession}
+          onClick={() => addSession()}
           className="p-1.5 rounded hover:bg-slate-700 text-slate-400 hover:text-white ml-1 shrink-0"
           title="New terminal"
         >
@@ -249,7 +225,7 @@ export function Terminal() {
             <AlertCircle size={32} className="mx-auto text-slate-600" />
             <p className="text-sm">No terminal sessions</p>
             <button
-              onClick={addSession}
+              onClick={() => addSession()}
               className="px-3 py-1.5 rounded bg-cyan-500/10 text-cyan-400 hover:bg-cyan-500/20 text-sm"
             >
               Open Terminal

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -72,6 +72,7 @@ export function Terminal() {
   const [sessions, setSessions] = useState<TermSession[]>([]);
   const [activeId, setActiveId] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const wiredIds = useRef<Set<number>>(new Set());
   const activeSession = sessions.find((s) => s.id === activeId) ?? null;
 
   const addSession = useCallback(() => {
@@ -87,6 +88,7 @@ export function Terminal() {
         if (session) {
           session.ws?.close();
           session.term.dispose();
+          wiredIds.current.delete(id);
         }
         const next = prev.filter((s) => s.id !== id);
         if (activeId === id) {
@@ -127,8 +129,8 @@ export function Terminal() {
       if (!ws || ws.readyState > WebSocket.OPEN) continue;
 
       // Skip if already wired
-      if ((ws as unknown as { _apeWired?: boolean })._apeWired) continue;
-      (ws as unknown as { _apeWired?: boolean })._apeWired = true;
+      if (wiredIds.current.has(session.id)) continue;
+      wiredIds.current.add(session.id);
 
       ws.onopen = () => {
         setSessions((prev) =>

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -1,0 +1,262 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import { AlertCircle, Plus, X, TerminalSquare } from "lucide-react";
+import { Terminal as XTerm } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
+import "@xterm/xterm/css/xterm.css";
+
+const WS_BASE = `ws://${window.location.host}/api/ec2/terminal`;
+
+interface TermSession {
+  id: number;
+  label: string;
+  term: XTerm;
+  fitAddon: FitAddon;
+  ws: WebSocket | null;
+  status: "connecting" | "connected" | "disconnected";
+}
+
+let nextId = 1;
+
+function createSession(connId?: string): TermSession {
+  const id = nextId++;
+  const term = new XTerm({
+    cursorBlink: true,
+    fontSize: 13,
+    fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace",
+    theme: {
+      background: "#0f172a",
+      foreground: "#e2e8f0",
+      cursor: "#22d3ee",
+      selectionBackground: "#334155",
+      black: "#0f172a",
+      red: "#f87171",
+      green: "#4ade80",
+      yellow: "#facc15",
+      blue: "#60a5fa",
+      magenta: "#c084fc",
+      cyan: "#22d3ee",
+      white: "#e2e8f0",
+      brightBlack: "#475569",
+      brightRed: "#fca5a5",
+      brightGreen: "#86efac",
+      brightYellow: "#fde68a",
+      brightBlue: "#93c5fd",
+      brightMagenta: "#d8b4fe",
+      brightCyan: "#67e8f9",
+      brightWhite: "#f8fafc",
+    },
+    scrollback: 5000,
+    allowProposedApi: true,
+  });
+
+  const fitAddon = new FitAddon();
+  term.loadAddon(fitAddon);
+  term.loadAddon(new WebLinksAddon());
+
+  const params = connId ? `?conn=${encodeURIComponent(connId)}` : "";
+  const ws = new WebSocket(`${WS_BASE}${params}`);
+  ws.binaryType = "arraybuffer";
+
+  return {
+    id,
+    label: `Terminal ${id}`,
+    term,
+    fitAddon,
+    ws,
+    status: "connecting",
+  };
+}
+
+export function Terminal() {
+  const [sessions, setSessions] = useState<TermSession[]>([]);
+  const [activeId, setActiveId] = useState<number | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const activeSession = sessions.find((s) => s.id === activeId) ?? null;
+
+  const addSession = useCallback(() => {
+    const session = createSession();
+    setSessions((prev) => [...prev, session]);
+    setActiveId(session.id);
+  }, []);
+
+  const removeSession = useCallback(
+    (id: number) => {
+      setSessions((prev) => {
+        const session = prev.find((s) => s.id === id);
+        if (session) {
+          session.ws?.close();
+          session.term.dispose();
+        }
+        const next = prev.filter((s) => s.id !== id);
+        if (activeId === id) {
+          setActiveId(next.length > 0 ? next[next.length - 1].id : null);
+        }
+        return next;
+      });
+    },
+    [activeId],
+  );
+
+  // Auto-create first session on mount
+  useEffect(() => {
+    if (sessions.length === 0) {
+      addSession();
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Attach active terminal to DOM
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || !activeSession) return;
+
+    // Clear container and attach
+    el.innerHTML = "";
+    activeSession.term.open(el);
+
+    // Fit after a frame so the container dimensions are settled
+    requestAnimationFrame(() => {
+      activeSession.fitAddon.fit();
+    });
+  }, [activeSession]);
+
+  // Wire up WebSocket ↔ xterm for each session
+  useEffect(() => {
+    for (const session of sessions) {
+      const { ws, term } = session;
+      if (!ws || ws.readyState > WebSocket.OPEN) continue;
+
+      // Skip if already wired
+      if ((ws as unknown as { _apeWired?: boolean })._apeWired) continue;
+      (ws as unknown as { _apeWired?: boolean })._apeWired = true;
+
+      ws.onopen = () => {
+        setSessions((prev) =>
+          prev.map((s) => (s.id === session.id ? { ...s, status: "connected" as const } : s)),
+        );
+        // Send initial size
+        const msg = JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows });
+        ws.send(msg);
+      };
+
+      ws.onmessage = (ev) => {
+        if (ev.data instanceof ArrayBuffer) {
+          term.write(new Uint8Array(ev.data));
+        } else {
+          term.write(ev.data);
+        }
+      };
+
+      ws.onclose = () => {
+        setSessions((prev) =>
+          prev.map((s) =>
+            s.id === session.id ? { ...s, status: "disconnected" as const } : s,
+          ),
+        );
+        term.write("\r\n\x1b[90m--- session ended ---\x1b[0m\r\n");
+      };
+
+      ws.onerror = () => {
+        setSessions((prev) =>
+          prev.map((s) =>
+            s.id === session.id ? { ...s, status: "disconnected" as const } : s,
+          ),
+        );
+      };
+
+      // Terminal input → WebSocket (binary)
+      term.onData((data) => {
+        if (ws.readyState === WebSocket.OPEN) {
+          const encoder = new TextEncoder();
+          ws.send(encoder.encode(data));
+        }
+      });
+    }
+  }, [sessions]);
+
+  // Resize observer
+  useEffect(() => {
+    if (!containerRef.current || !activeSession) return;
+
+    const observer = new ResizeObserver(() => {
+      activeSession.fitAddon.fit();
+      if (activeSession.ws?.readyState === WebSocket.OPEN) {
+        const msg = JSON.stringify({
+          type: "resize",
+          cols: activeSession.term.cols,
+          rows: activeSession.term.rows,
+        });
+        activeSession.ws.send(msg);
+      }
+    });
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, [activeSession]);
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Tab bar */}
+      <div className="flex items-center px-2 bg-slate-800/50 border-b border-slate-700">
+        <div className="flex items-center gap-1 overflow-x-auto flex-1 py-1">
+          {sessions.map((s) => (
+            <button
+              key={s.id}
+              onClick={() => setActiveId(s.id)}
+              className={`flex items-center gap-1.5 px-3 py-1 rounded text-xs whitespace-nowrap transition-colors ${
+                s.id === activeId
+                  ? "bg-slate-700 text-white"
+                  : "text-slate-400 hover:text-white hover:bg-slate-800"
+              }`}
+            >
+              <TerminalSquare size={12} />
+              <span>{s.label}</span>
+              {s.status === "connecting" && (
+                <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
+              )}
+              {s.status === "connected" && (
+                <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
+              )}
+              {s.status === "disconnected" && (
+                <span className="w-1.5 h-1.5 rounded-full bg-red-400" />
+              )}
+              <span
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeSession(s.id);
+                }}
+                className="ml-1 p-0.5 rounded hover:bg-slate-600 text-slate-500 hover:text-white"
+              >
+                <X size={10} />
+              </span>
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={addSession}
+          className="p-1.5 rounded hover:bg-slate-700 text-slate-400 hover:text-white ml-1 shrink-0"
+          title="New terminal"
+        >
+          <Plus size={14} />
+        </button>
+      </div>
+
+      {/* Terminal area */}
+      {sessions.length === 0 ? (
+        <div className="flex-1 flex items-center justify-center text-slate-500">
+          <div className="text-center space-y-2">
+            <AlertCircle size={32} className="mx-auto text-slate-600" />
+            <p className="text-sm">No terminal sessions</p>
+            <button
+              onClick={addSession}
+              className="px-3 py-1.5 rounded bg-cyan-500/10 text-cyan-400 hover:bg-cyan-500/20 text-sm"
+            >
+              Open Terminal
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div ref={containerRef} className="flex-1 min-h-0 bg-[#0f172a] p-1" />
+      )}
+    </div>
+  );
+}

--- a/go.mod
+++ b/go.mod
@@ -39,4 +39,5 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
+	nhooyr.io/websocket v1.8.17 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -81,3 +81,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+nhooyr.io/websocket v1.8.17 h1:KEVeLJkUywCKVsnLIDlD/5gtayKp8VoCkksHCGGfT9Y=
+nhooyr.io/websocket v1.8.17/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/internal/api/connections.go
+++ b/internal/api/connections.go
@@ -46,6 +46,23 @@ func (m *ConnectionManager) Get(id string) sftp.SFTPClient {
 	return c
 }
 
+// GetRaw returns the concrete *sftp.Client (needed for SSH session creation).
+func (m *ConnectionManager) GetRaw(id string) *sftp.Client {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.connections[id]
+}
+
+// DefaultRaw returns the first connection as a concrete *sftp.Client.
+func (m *ConnectionManager) DefaultRaw() *sftp.Client {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if len(m.order) == 0 {
+		return nil
+	}
+	return m.connections[m.order[0]]
+}
+
 // Default returns the first (most recently added) connection, or nil.
 func (m *ConnectionManager) Default() sftp.SFTPClient {
 	m.mu.RLock()

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -27,6 +27,10 @@ func NewRouter(connMgr *ConnectionManager, s3Client s3.S3Client, pgFactory *post
 	mux.HandleFunc("/api/ec2/mkdir", ec2.HandleMkdir)           // POST ?path=
 	mux.HandleFunc("/api/ec2/stat", ec2.HandleStat)             // GET  ?path=
 
+	// Terminal (WebSocket → SSH PTY)
+	term := NewTerminalHandler(connMgr)
+	mux.HandleFunc("/api/ec2/terminal", term.HandleTerminal) // GET (WebSocket upgrade)
+
 	// Dashboard
 	dash := NewDashboardHandler(connMgr)
 	mux.HandleFunc("/api/dashboard/overview", dash.HandleOverview)

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+
+	"golang.org/x/crypto/ssh"
+	"nhooyr.io/websocket"
+
+	sftppkg "github.com/dongchankim/ape/internal/sftp"
+)
+
+// TerminalHandler handles WebSocket-based SSH terminal sessions.
+type TerminalHandler struct {
+	connMgr *ConnectionManager
+}
+
+// NewTerminalHandler creates a new TerminalHandler.
+func NewTerminalHandler(connMgr *ConnectionManager) *TerminalHandler {
+	return &TerminalHandler{connMgr: connMgr}
+}
+
+// resizeMsg is the JSON payload for terminal resize events.
+type resizeMsg struct {
+	Type string `json:"type"`
+	Cols int    `json:"cols"`
+	Rows int    `json:"rows"`
+}
+
+func (h *TerminalHandler) getClient(r *http.Request) *sftppkg.Client {
+	connID := r.URL.Query().Get("conn")
+	if connID != "" {
+		return h.connMgr.GetRaw(connID)
+	}
+	return h.connMgr.DefaultRaw()
+}
+
+// HandleTerminal handles GET /api/ec2/terminal — upgrades to WebSocket and
+// bridges it to an SSH PTY session on the connected EC2 instance.
+func (h *TerminalHandler) HandleTerminal(w http.ResponseWriter, r *http.Request) {
+	client := h.getClient(r)
+	if client == nil {
+		writeError(w, http.StatusBadRequest, "no active connection")
+		return
+	}
+
+	ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		// localhost only — no origin check needed.
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		slog.Error("websocket accept failed", "err", err)
+		return
+	}
+	defer ws.Close(websocket.StatusNormalClosure, "session ended")
+
+	session, err := client.NewSession()
+	if err != nil {
+		slog.Error("failed to create SSH session", "err", err)
+		ws.Close(websocket.StatusInternalError, "failed to create SSH session")
+		return
+	}
+	defer session.Close()
+
+	// Request PTY with reasonable defaults; client will send a resize soon.
+	if err := session.RequestPty("xterm-256color", 24, 80, ssh.TerminalModes{
+		ssh.ECHO:          1,
+		ssh.TTY_OP_ISPEED: 14400,
+		ssh.TTY_OP_OSPEED: 14400,
+	}); err != nil {
+		slog.Error("failed to request PTY", "err", err)
+		ws.Close(websocket.StatusInternalError, "failed to request PTY")
+		return
+	}
+
+	stdinPipe, err := session.StdinPipe()
+	if err != nil {
+		slog.Error("failed to get stdin pipe", "err", err)
+		return
+	}
+	stdoutPipe, err := session.StdoutPipe()
+	if err != nil {
+		slog.Error("failed to get stdout pipe", "err", err)
+		return
+	}
+	stderrPipe, err := session.StderrPipe()
+	if err != nil {
+		slog.Error("failed to get stderr pipe", "err", err)
+		return
+	}
+
+	if err := session.Shell(); err != nil {
+		slog.Error("failed to start shell", "err", err)
+		ws.Close(websocket.StatusInternalError, "failed to start shell")
+		return
+	}
+
+	ctx := r.Context()
+	var wg sync.WaitGroup
+
+	// SSH stdout → WebSocket
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 8192)
+		for {
+			n, err := stdoutPipe.Read(buf)
+			if n > 0 {
+				if writeErr := ws.Write(ctx, websocket.MessageBinary, buf[:n]); writeErr != nil {
+					return
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	// SSH stderr → WebSocket
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 4096)
+		for {
+			n, err := stderrPipe.Read(buf)
+			if n > 0 {
+				if writeErr := ws.Write(ctx, websocket.MessageBinary, buf[:n]); writeErr != nil {
+					return
+				}
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	// WebSocket → SSH stdin (binary = keystrokes, text = control JSON)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer stdinPipe.Close()
+		for {
+			msgType, data, err := ws.Read(ctx)
+			if err != nil {
+				return
+			}
+
+			if msgType == websocket.MessageText {
+				var msg resizeMsg
+				if json.Unmarshal(data, &msg) == nil && msg.Type == "resize" {
+					if msg.Cols > 0 && msg.Rows > 0 {
+						_ = session.WindowChange(msg.Rows, msg.Cols)
+					}
+				}
+				continue
+			}
+
+			// Binary message = raw terminal input
+			if _, err := stdinPipe.Write(data); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Wait for shell to exit, then clean up.
+	_ = session.Wait()
+	// Cancel context to unblock goroutines.
+	ws.Close(websocket.StatusNormalClosure, "shell exited")
+	// Drain remaining output.
+	_ = io.ReadAll(stdoutPipe)
+	_ = io.ReadAll(stderrPipe)
+	wg.Wait()
+}

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -170,7 +170,7 @@ func (h *TerminalHandler) HandleTerminal(w http.ResponseWriter, r *http.Request)
 	// Cancel context to unblock goroutines.
 	ws.Close(websocket.StatusNormalClosure, "shell exited")
 	// Drain remaining output.
-	_ = io.ReadAll(stdoutPipe)
-	_ = io.ReadAll(stderrPipe)
+	_, _ = io.ReadAll(stdoutPipe)
+	_, _ = io.ReadAll(stderrPipe)
 	wg.Wait()
 }

--- a/internal/sftp/client.go
+++ b/internal/sftp/client.go
@@ -174,6 +174,12 @@ func (c *Client) handleForward(local net.Conn, remoteAddr string) {
 	<-done
 }
 
+// NewSession creates a new SSH session on the underlying connection.
+// Callers are responsible for closing the returned session.
+func (c *Client) NewSession() (*ssh.Session, error) {
+	return c.sshClient.NewSession()
+}
+
 // Close shuts down the SFTP session and SSH connection.
 func (c *Client) Close() error {
 	if c.sftpClient != nil {


### PR DESCRIPTION
## Summary
- 브라우저에서 EC2 인스턴스에 SSH 셸 접속 가능한 웹 터미널 구현
- **Backend**: `nhooyr.io/websocket`으로 WebSocket 업그레이드 → SSH PTY 세션 브릿지
- **Frontend**: `@xterm/xterm` + `@xterm/addon-fit` + `@xterm/addon-web-links`
- 사이드바에 Terminal 탭 추가 (Dashboard, EC2, S3, RDS, **Terminal**)

## Key Features
- WebSocket endpoint: `GET /api/ec2/terminal?conn=<id>`
- SSH PTY (xterm-256color) with window resize handling
- Multiple concurrent terminal sessions (탭 UI)
- Auto-fit on window resize
- Dark theme consistent with existing UI
- URL link detection, copy/paste support

## Files Changed
| File | Change |
|------|--------|
| `internal/api/terminal_handler.go` | **New** — WebSocket ↔ SSH PTY bridge |
| `internal/sftp/client.go` | Add `NewSession()` method for SSH session creation |
| `internal/api/connections.go` | Add `GetRaw()`, `DefaultRaw()` for concrete client access |
| `internal/api/router.go` | Register `/api/ec2/terminal` endpoint |
| `frontend/src/components/Terminal.tsx` | **New** — xterm.js terminal component |
| `frontend/src/components/Sidebar.tsx` | Add Terminal nav item |
| `frontend/src/App.tsx` | Add Terminal view |
| `go.mod` | Add `nhooyr.io/websocket` |
| `frontend/package.json` | Add `@xterm/*` packages |

Closes #2

## Test plan
- [ ] Terminal 탭 클릭 → 자동으로 첫 번째 세션 생성 확인
- [ ] 셸 명령어 입력/출력 동작 확인 (ls, pwd, cat 등)
- [ ] 브라우저 창 리사이즈 시 터미널 크기 자동 조정 확인
- [ ] "+" 버튼으로 복수 터미널 세션 생성 확인
- [ ] 탭 전환 시 각 세션 독립 유지 확인
- [ ] "X" 버튼으로 세션 종료 확인
- [ ] 연결 끊김 시 "session ended" 메시지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)